### PR TITLE
Allow custom Result types on scope

### DIFF
--- a/dynja_derive/src/lib.rs
+++ b/dynja_derive/src/lib.rs
@@ -60,7 +60,7 @@ pub fn derive_template(input: TokenStream) -> TokenStream {
         }
 
         impl #impl_generics #struct_ident #ty_generics #where_clause {
-            fn render(&self) -> Result<String, dynja::minijinja::Error> {
+            fn render(&self) -> std::result::Result<String, dynja::minijinja::Error> {
                 let mut templates = dynja::environment().lock().unwrap();
                 if cfg!(debug_assertions) {
                     templates.clear_templates(); // Necessary for hot reloading.


### PR DESCRIPTION
```rust
type Result<T> = ...;

#[derive(dynja::Template)] // error
#[template(path = "...")]
struct Foo;
```

this was not allowed, cause an error inside the procedural macro, since its common pattern to override Result or use anyhow in rust I think this simple fix is needed